### PR TITLE
fix #16,  fix #10

### DIFF
--- a/src/getcensus.ado
+++ b/src/getcensus.ado
@@ -445,8 +445,6 @@ local kids_nativity "B05009"
 local kids_pov_parents_nativity "B05010"
 
 ** Create "estimates" based on expanding local if not from table
-// this works because keywords are lower case and strpos is case sensitive
-
 local prepackaged ""
 foreach estimate in `estimates' {
     if !ustrregexm("`estimates'", "^(B|C|DP|S)(?=\d)", 1) {

--- a/src/getcensus.ado
+++ b/src/getcensus.ado
@@ -449,7 +449,7 @@ local kids_pov_parents_nativity "B05010"
 
 local prepackaged ""
 foreach estimate in `estimates' {
-    if !inlist(1, strpos(upper("`estimates'"), "B"), strpos(upper("`estimates'"), "C"), strpos(upper("`estimates'"), "DP"), strpos(upper("`estimates'"), "S")) {
+    if !ustrregexm("`estimates'", "^(B|C|DP|S)(?=\d)", 1) {
         local prepackaged "`prepackaged' ``estimate''"
     }
     else {


### PR DESCRIPTION
I think this'll fix the keyword problems. 

Traceback: Keywords start with the same letter as tables -> expression that detects keywords did not detect them, because the expression uppercase-d input _before_ evaluating it (lowercase of keywords was supposed to distinguish them from tables) -> keyword macro did not expand into list of estimates -> keyword passed directly to API -> API call failed.

I replaced the expression that detects keywords. If the user input does not start with B, C, DP, or S (case insensitive) _followed by_ a number, the user input is detected to be a keyword and the macro is expanded.